### PR TITLE
Add Windows certificate store info in installRoot instructions

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -75,6 +75,7 @@
         <button id="initTestButton">Run Browser Test</button>
         <div id="installRoot" style="display:none">
           <p>To run this test you need to install the <a href="root.crt">root CA</a> for this suite. Make sure you remove it from your trust store afterward. Refresh this page once it is installed.</p>
+          <p>Windows: If your browser uses Windows&#39; certificate stores then install the certificate in the trusted root store, do not use automatic selection. You may need to restart your browser for the certificate to be immediately recognized.</p>
         </div>
         <div class="testResults"></div>
       </div> <!-- testBrowserTab -->


### PR DESCRIPTION
- Document that the root CA must be added to the trusted root store and
  not the default automatic selection.

Because automatic selection will add the certificate to the wrong store.

- Document that it may be necessary to restart the browser for the root
  certificate to be immediately recognized.

Because it can take over 10 minutes for the new root certificate to be
recognized if the browser is not restarted. This was reproducible in a
clean VM of Windows 7 Enterprise x64 with Chrome 58.0.3029.81.