### PR TITLE
Fix link to non-browser testsuites at GitHub

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -68,7 +68,7 @@
         <p>The Name Constraints extension along with its verification is defined in <a href="https://tools.ietf.org/html/rfc5280#section-4.2.1.10">RFC 5280</a>. Further useful information can be found in <a href="https://tools.ietf.org/html/rfc6125">RFC 6125</a> which defines how to identify a server's hostname from certificate extensions.</p>
 
         <h1>Testing Clients</h1>
-        <p>Browsers can be tested by visiting the <a href="#!test">test browser</a> tab on this website. Non-browser clients (such as Java and Python) can also be easily tested against the BetterTLS test suite. Check out the <a href="https://github.com/Netflix/bettertls/tree/master/nameconstraints/testsuites">testsuites</a> folder of the BetterTLS source repository for examples on how to do so.</p>
+        <p>Browsers can be tested by visiting the <a href="#!test">test browser</a> tab on this website. Non-browser clients (such as Java and Python) can also be easily tested against the BetterTLS test suite. Check out the <a href="https://github.com/Netflix/bettertls/tree/master/testsuites">testsuites</a> folder of the BetterTLS source repository for examples on how to do so.</p>
 
         <h1>Contribute</h1>
         <p>BetterTLS is <a href="https://github.com/Netflix/bettertls">open source software</a>. We encourage you to help add more tests, fix any issues you find in the existing test suite, or even fork it for use in your own software project. Pull requests are welcome!</p>


### PR DESCRIPTION
Link was broken, apparently since the first OSS commit (dfcd9860574c786e75ce4d7425b4d6a0ea5e10f5).  