### PR TITLE
#11 Add export-tests subcommand and add docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The following is an abbreviated example of what gets exported:
       "testCases": [
         {
           "id": 0,
+          "suite": "nameconstraints",
           "certificates": [
             "MII...",
             ...
@@ -232,14 +233,15 @@ The following is an abbreviated example of what gets exported:
 
 **TestCase**
 
-| Field Name | Description |
-| --- | --- |
-| id | The id of the test case. This id can be passed to the `bettertls get-test` command. |
-| certificates | The array of certificates for the test case, leaf first. Certificates are Base64-encoded DER format. |
-| hostname | The hostname that should be used by the client for subject name verification. This may be a DNS name or a stringified IP address. |
-| requiredFeatures | An array of features that the TLS implementation needs in order to run this test. The test should be skipped if any feature is not supported. |
-| expected | The expected behavior of the TLS implementation. Either "ACCEPT" or "REJECT" |
-| failureIsWarning | If true, getting an unexpected result on this test should just be considered a warning. See the note below. |
+| Field Name | Description                                                                                                                                                  |
+| --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id | The id of the test case. This id (along with "suite" below) can be passed to the `bettertls get-test` command. Note that ids are only unique within a suite. |
+| suite | The name of the test suite this test case belongs to.                                                                                                        |
+| certificates | The array of certificates for the test case, leaf first. Certificates are Base64-encoded DER format.                                                         |
+| hostname | The hostname that should be used by the client for subject name verification. This may be a DNS name or a stringified IP address.                            |
+| requiredFeatures | An array of features that the TLS implementation needs in order to run this test. The test should be skipped if any feature is not supported.                |
+| expected | The expected behavior of the TLS implementation. Either "ACCEPT" or "REJECT"                                                                                 |
+| failureIsWarning | If true, getting an unexpected result on this test should just be considered a warning. See the note below.                                                  |
 
 ### A note about the "failureIsWarning" tests
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The following is an abbreviated example of what gets exported:
       },
       "testCases": [
         {
+          "id": 0,
           "certificates": [
             "MII...",
             ...
@@ -233,6 +234,7 @@ The following is an abbreviated example of what gets exported:
 
 | Field Name | Description |
 | --- | --- |
+| id | The id of the test case. This id can be passed to the `bettertls get-test` command. |
 | certificates | The array of certificates for the test case, leaf first. Certificates are Base64-encoded DER format. |
 | hostname | The hostname that should be used by the client for subject name verification. This may be a DNS name or a stringified IP address. |
 | requiredFeatures | An array of features that the TLS implementation needs in order to run this test. The test should be skipped if any feature is not supported. |

--- a/test-suites/cmd/bettertls/export_tests.go
+++ b/test-suites/cmd/bettertls/export_tests.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/Netflix/bettertls/test-suites/certutil"
+	int_set "github.com/Netflix/bettertls/test-suites/int-set"
+	test_case "github.com/Netflix/bettertls/test-suites/test-case"
+	test_executor "github.com/Netflix/bettertls/test-suites/test-executor"
+	"io"
+	"os"
+)
+
+type testExport struct {
+	BetterTlsRevision string                  `json:"betterTlsRevision"`
+	TrustRoot         []byte                  `json:"trustRoot"`
+	Suites            map[string]*suiteExport `json:"suites"`
+}
+
+type suiteExport struct {
+	Features            []string          `json:"features"`
+	SanityCheckTestCase uint              `json:"sanityCheckTestCase"`
+	FeatureTestCases    map[string][]uint `json:"featureTestCases"`
+	TestCases           []*testCaseExport `json:"testCases"`
+}
+
+type testCaseExport struct {
+	Certificates     [][]byte `json:"certificates"`
+	Hostname         string   `json:"hostname"`
+	RequiredFeatures []string `json:"requiredFeatures"`
+	Expected         string   `json:"expected"`
+	FailureIsWarning bool     `json:"failureIsWarning"`
+}
+
+func exportTests(args []string) error {
+	flagSet := flag.NewFlagSet("run-tests", flag.ContinueOnError)
+	var suite string
+	flagSet.StringVar(&suite, "suite", "", "Export only the given suite instead of all suites.")
+	testCases := new(int_set.IntSet)
+	flagSet.Var(testCases, "testCase", "Export only the given test case(s) in the suite instead of all tests. Requires --suite to be specified as well. Use \"123,456-789\" syntax to include a range or set of cases.")
+	var outputPath string
+	flagSet.StringVar(&outputPath, "out", "", "Write to the given file instead of stdout.")
+
+	err := flagSet.Parse(args)
+	if err != nil {
+		return err
+	}
+
+	rootCa, rootKey, err := certutil.GenerateSelfSignedCert("bettertls_trust_root")
+	if err != nil {
+		return err
+	}
+	suites, err := test_executor.BuildTestSuitesWithRootCa(rootCa, rootKey)
+	if err != nil {
+		return err
+	}
+
+	output := new(testExport)
+	output.BetterTlsRevision = test_executor.GetBuildRevision()
+	output.TrustRoot = rootCa.Raw
+	output.Suites = make(map[string]*suiteExport)
+
+	for _, suiteName := range suites.GetProviderNames() {
+		if suite != "" && suiteName != suite {
+			continue
+		}
+		provider := suites.GetProvider(suiteName)
+
+		suiteExport := new(suiteExport)
+		suiteExport.Features = make([]string, 0)
+		suiteExport.SanityCheckTestCase, err = provider.GetSanityCheckTestCase()
+		suiteExport.FeatureTestCases = make(map[string][]uint)
+		for _, feature := range provider.GetFeatures() {
+			featureName := provider.DescribeFeature(feature)
+			suiteExport.Features = append(suiteExport.Features, featureName)
+			testCases, err := provider.GetTestCasesForFeature(feature)
+			if err != nil {
+				return err
+			}
+			suiteExport.FeatureTestCases[featureName] = testCases
+		}
+		if err != nil {
+			return err
+		}
+		testCaseCount, err := provider.GetTestCaseCount()
+		if err != nil {
+			return nil
+		}
+		for i := uint(0); i < testCaseCount; i++ {
+			testCase, err := provider.GetTestCase(i)
+			if err != nil {
+				return err
+			}
+			testCaseExport := new(testCaseExport)
+			certs, err := testCase.GetCertificates(rootCa, rootKey)
+			if err != nil {
+				return err
+			}
+			testCaseExport.Certificates = certs.Certificate
+			testCaseExport.Hostname = testCase.GetHostname()
+			testCaseExport.RequiredFeatures = make([]string, 0)
+			for _, feature := range testCase.RequiredFeatures() {
+				testCaseExport.RequiredFeatures = append(testCaseExport.RequiredFeatures, provider.DescribeFeature(feature))
+			}
+			switch testCase.ExpectedResult() {
+			case test_case.EXPECTED_RESULT_PASS:
+				testCaseExport.Expected = "ACCEPT"
+			case test_case.EXPECTED_RESULT_FAIL:
+				testCaseExport.Expected = "REJECT"
+			case test_case.EXPECTED_RESULT_SOFT_PASS:
+				testCaseExport.Expected = "ACCEPT"
+				testCaseExport.FailureIsWarning = true
+			case test_case.EXPECTED_RESULT_SOFT_FAIL:
+				testCaseExport.Expected = "REJECT"
+				testCaseExport.FailureIsWarning = true
+			default:
+				panic(fmt.Errorf("unhandled expected result: %v", testCase.ExpectedResult()))
+			}
+
+			suiteExport.TestCases = append(suiteExport.TestCases, testCaseExport)
+		}
+
+		output.Suites[suiteName] = suiteExport
+	}
+
+	var out io.Writer
+	if outputPath == "" {
+		out = os.Stdout
+	} else {
+		f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		out = f
+	}
+	err = json.NewEncoder(out).Encode(output)
+	if err != nil {
+		return fmt.Errorf("failed to save results: %v", err)
+	}
+
+	return nil
+}

--- a/test-suites/cmd/bettertls/export_tests.go
+++ b/test-suites/cmd/bettertls/export_tests.go
@@ -26,6 +26,7 @@ type suiteExport struct {
 }
 
 type testCaseExport struct {
+	Id               uint     `json:"id"`
 	Certificates     [][]byte `json:"certificates"`
 	Hostname         string   `json:"hostname"`
 	RequiredFeatures []string `json:"requiredFeatures"`
@@ -93,6 +94,7 @@ func exportTests(args []string) error {
 				return err
 			}
 			testCaseExport := new(testCaseExport)
+			testCaseExport.Id = i
 			certs, err := testCase.GetCertificates(rootCa, rootKey)
 			if err != nil {
 				return err

--- a/test-suites/cmd/bettertls/export_tests.go
+++ b/test-suites/cmd/bettertls/export_tests.go
@@ -27,6 +27,7 @@ type suiteExport struct {
 
 type testCaseExport struct {
 	Id               uint     `json:"id"`
+	Suite            string   `json:"suite"`
 	Certificates     [][]byte `json:"certificates"`
 	Hostname         string   `json:"hostname"`
 	RequiredFeatures []string `json:"requiredFeatures"`
@@ -95,6 +96,7 @@ func exportTests(args []string) error {
 			}
 			testCaseExport := new(testCaseExport)
 			testCaseExport.Id = i
+			testCaseExport.Suite = provider.Name()
 			certs, err := testCase.GetCertificates(rootCa, rootKey)
 			if err != nil {
 				return err

--- a/test-suites/cmd/bettertls/main.go
+++ b/test-suites/cmd/bettertls/main.go
@@ -14,6 +14,7 @@ func main() {
 		"run-tests":          runTests,
 		"generate-manifests": generateManifests,
 		"show-results":       showResults,
+		"export-tests":       exportTests,
 	}
 
 	var subcommand func([]string) error


### PR DESCRIPTION
Tests can be exported with:

```
go run ./cmd/bettertls export-tests
```

The following is an abbreviated example of what gets exported:

```
{
  "betterTlsRevision": "939077295c05d36c53f1f386fc3ec55167360f3a",
  "trustRoot": "MII...",
  "suites": {
    "nameconstraints": {
      "features": ["NAME_CONSTRAINTS", "VALIDATE_DNS", "VALIDATE_IP"],
      "sanityCheckTestCase": 0,
      "featureTestCases": {
        "NAME_CONSTRAINTS": [1],
        "VALIDATE_DNS": [2,3],
        "VALIDATE_IP": [4,5]
      },
      "testCases": [
        {
          "certificates": [
            "MII...",
            ...
          ],
          "hostname": "test.localhost",
          "requiredFeatures": [],
          "expected": "ACCEPT",
          "failureIsWarning": false
        },
        ...
      ]
    }
  }
}
```

