### PR TITLE
test-suites/pathbuilding: add EKU to EE certs

### DIFF
--- a/test-suites/pathbuilding/generate_certs.go
+++ b/test-suites/pathbuilding/generate_certs.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+
 	"github.com/Netflix/bettertls/test-suites/certutil"
 )
 
@@ -51,6 +52,7 @@ func GenerateCerts(rootCa *x509.Certificate, rootKey crypto.Signer, leafDnsName 
 				SerialNumber: certutil.RandomString(),
 			}
 			template.DNSNames = []string{leafDnsName}
+			template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 		}
 
 		if isInvalid {


### PR DESCRIPTION
This adds EKUs to all EE certs generated in the `pathbuilding` suite, similar to EEs generated in the `nameconstraints` suite.

Manually confirmed that EKUs are now present by running `bettertls export-tests` and decoding a few EEs in the `pathbuilding` suite.

Closes #23.