### PR TITLE
Export LoadCert helper, reuse for export-tests

### DIFF
--- a/test-suites/certutil/cert_util.go
+++ b/test-suites/certutil/cert_util.go
@@ -7,9 +7,14 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"github.com/google/uuid"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
 	"math/big"
+	"os"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const SUBJECT_ORGANIZATION = "bettertls.com"
@@ -77,4 +82,70 @@ func GenerateSelfSignedCert(commonName string) (*x509.Certificate, crypto.Signer
 	}
 
 	return caCert, caKey, nil
+}
+
+func LoadCert(rootCa string) (*x509.Certificate, crypto.Signer, error) {
+	var rootCert *x509.Certificate
+	var rootKey crypto.Signer
+
+	if _, err := os.Stat(rootCa); os.IsNotExist(err) {
+		rootCert, rootKey, err = GenerateSelfSignedCert("bettertls_trust_root")
+		if err != nil {
+			return nil, nil, err
+		}
+		f, err := os.OpenFile(rootCa, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer f.Close()
+		err = pem.Encode(f, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: rootCert.Raw,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		rootKeyBytes, err := x509.MarshalPKCS8PrivateKey(rootKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		err = pem.Encode(f, &pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: rootKeyBytes,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		f.Close()
+	} else {
+		data, err := ioutil.ReadFile(rootCa)
+		if err != nil {
+			return nil, nil, err
+		}
+		for len(data) > 0 && (rootCert == nil || rootKey == nil) {
+			block, rest := pem.Decode(data)
+			if block == nil {
+				break
+			}
+			if block.Type == "CERTIFICATE" {
+				rootCert, err = x509.ParseCertificate(block.Bytes)
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+			if block.Type == "PRIVATE KEY" {
+				rootKeyPV, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+				if err != nil {
+					return nil, nil, err
+				}
+				rootKey = rootKeyPV.(crypto.Signer)
+			}
+			data = rest
+		}
+		if rootCert == nil || rootKey == nil {
+			return nil, nil, fmt.Errorf("rootCa file did not include certificate and key")
+		}
+	}
+
+	return rootCert, rootKey, nil
 }


### PR DESCRIPTION
This adds a new `certutil.LoadCert` helper function, which I created by carving the logic out of `runServer`. 

It also adds the `-rootCa` flag to `bettertls export-tests`, mirroring the extant flag on `bettertls server`. I manually confirmed that using the flag both creates and restores the CA and CA key, as expected.

Closes #22.